### PR TITLE
Allow using mouse on touchscreen computer

### DIFF
--- a/frontend/src/components/DatePicker.vue
+++ b/frontend/src/components/DatePicker.vue
@@ -24,8 +24,6 @@
 </template>
 
 <script>
-import { isTouchEnabled } from "@/utils"
-
 export default {
   name: "DatePicker",
 
@@ -47,8 +45,6 @@ export default {
   methods: {
     /** Start drag */
     mousedown(date) {
-      if (isTouchEnabled()) return
-
       this.dragging = true
       this.setDragState(date)
       this.addRemoveDate(date)

--- a/frontend/src/components/schedule_overlap/ScheduleOverlap.vue
+++ b/frontend/src/components/schedule_overlap/ScheduleOverlap.vue
@@ -1624,11 +1624,10 @@ export default {
         timesEl.addEventListener("touchmove", this.moveDrag)
         timesEl.addEventListener("touchend", this.endDrag)
         timesEl.addEventListener("touchcancel", this.endDrag)
-      } else {
-        timesEl.addEventListener("mousedown", this.startDrag)
-        timesEl.addEventListener("mousemove", this.moveDrag)
-        timesEl.addEventListener("mouseup", this.endDrag)
       }
+      timesEl.addEventListener("mousedown", this.startDrag)
+      timesEl.addEventListener("mousemove", this.moveDrag)
+      timesEl.addEventListener("mouseup", this.endDrag)
     }
   },
   beforeDestroy() {


### PR DESCRIPTION
I have a touchscreen laptop and was confused when I could only use my touchscreen to edit my availability. I edited the code to remove those constraints so that users with touchscreen laptops can still use their mouse. Let me know if there's a reason I didn't think of such that removing this constraint causes issues.