### PR TITLE
Sanitize eventId by removing . characters

### DIFF
--- a/frontend/src/views/Event.vue
+++ b/frontend/src/views/Event.vue
@@ -543,7 +543,8 @@ export default {
     },
     /** Refresh event details */
     async refreshEvent() {
-      this.event = await get(`/events/${this.eventId}`)
+      let sanitizedId = this.eventId.replaceAll(".", "")
+      this.event = await get(`/events/${sanitizedId}`)
       processEvent(this.event)
     },
 


### PR DESCRIPTION
Fixes #100 by removing all `.` characters in an eventId (`/e/:eventId`). This can be an issue when someone sends a URL at the end of a sentence, like "hey, check out `https://schej.it/e/123456."