### PR TITLE
Make email strings lowercase to avoid case sensitivity bugs

### DIFF
--- a/frontend/src/views/Group.vue
+++ b/frontend/src/views/Group.vue
@@ -54,7 +54,7 @@ export default {
 
       let found = false
       for (const attendee of attendees) {
-        if (attendee.email === this.authUser.email) {
+        if (attendee.email.toLowerCase() === this.authUser.email.toLowerCase()) {
           // The line below is commented out because we want attendee to be able to rejoin group after declining
           // if (attendee.declined) return true
 


### PR DESCRIPTION
Fixes #109 

Converts both sides of the email comparison to lowercase in the case where the user entered the email for an attendee with an upper-case letter. We can alternatively or additionally fix this when the email is entered to start with.