### PR TITLE
Make background "redish" pink -- similar to when2meet

### DIFF
--- a/frontend/src/components/schedule_overlap/ScheduleOverlap.vue
+++ b/frontend/src/components/schedule_overlap/ScheduleOverlap.vue
@@ -173,6 +173,7 @@
                       id="drag-section"
                       data-long-press-delay="500"
                       class="tw-relative tw-flex"
+                      style="background-color: #ffdede;"
                       @mouseleave="resetCurTimeslot"
                     >
                       <!-- Loader -->


### PR DESCRIPTION
It makes it much more obvious that the slot is not available and not just "empty" which seems to cause confusion in early adopters.

Note: I did not test it, just toyed around with "Inspect" in the browser to get the effect. Should look like

![image](https://github.com/user-attachments/assets/5f512f40-f031-4630-a6c3-fbc2de02696b)

after this change